### PR TITLE
Create effective backlinks between pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ header_pages:
   - guides/week-13-16.md
   - guides/week-17-24.md
   - guides/nighttime-guide.md
+  - guides/command-vocabulary.md
   - guides/barking-suppression.md
 
 # BELOW: add site-wide defaults to unify format of guide pages

--- a/guides/command-vocabulary.md
+++ b/guides/command-vocabulary.md
@@ -1,0 +1,50 @@
+---
+layout: page
+title: "Command Vocabulary & Marker Cues"
+description: "Quick reference for Thunder's commands, marker words, and release cues"
+permalink: /command-vocabulary/
+nav_order: 5
+---
+
+# ⚡ Command Vocabulary & Marker Cues
+
+A concise lookup table of every word Thunder hears in training. Keep sessions crystal-clear by using **one cue, one meaning**.
+
+---
+## 🎯 Marker Words
+| Word | Type | When to Use | Example |
+|------|------|-------------|---------|
+| **Yes** | Event Marker | The moment Thunder performs the desired behavior | Dog's nose touches hand → "Yes!" → treat |
+| **Good** | Duration Marker | While Thunder *maintains* the behavior | Dog stays in a sit → "Good...Good..." |
+| **Okay** | Release Word | To end the current behavior & release Thunder | After a stay → "Okay!" → free play |
+
+> 💡 Stick to these three words. Mixing markers confuses timing and weakens learning.
+
+---
+## 🐾 Core Obedience Cues
+| Cue | Behavior | Notes |
+|-----|----------|-------|
+| **Thunder** | Name Recognition | Look at handler & await next cue |
+| **Sit** | Sit until released | Pair with duration marker "Good" |
+| **Down** | Lie down until released | Introduce in Week 17–24 |
+| **Touch** | Nose-target handler's hand | Great for redirecting focus |
+| **Come** | Recall to front position | Always high-value reward |
+| **Place** (optional) | Go to bed/mat & stay | Useful in busy environments |
+
+---
+## 🚀 How to Introduce a New Cue
+1. Lure or capture the behavior.
+2. The instant it happens, **mark "Yes"**.
+3. Reward. Repeat 3-5×.
+4. Once predictable, say the cue *before* the behavior.
+5. Fade lures and add duration with **"Good."**
+
+---
+## 🔗 Where This Guide Is Used
+Referenced in:
+- [Week 8-10 Schedule]({{ "/puppy-schedule/" | relative_url }})
+- [Week 11-12 Schedule]({{ "/week-11-12/" | relative_url }})
+- [Week 13-16 Schedule]({{ "/week-13-16/" | relative_url }})
+- [Week 17-24 Schedule]({{ "/week-17-24/" | relative_url }})
+
+Use it anytime you need to **verify wording** before a session.

--- a/guides/crate-training.md
+++ b/guides/crate-training.md
@@ -77,4 +77,10 @@ A well-introduced crate becomes your puppy's **safe, calm home base**—not a pu
 * [Nighttime Potty Guide]({{ "/nighttime-guide/" | relative_url }}) – integrates with the overnight routine above.
 
 ---
-*[Return to Week 8–10 Schedule]({{ "/puppy-schedule/" | relative_url }})* 
+## 🔗 Where This Fits In
+
+Referenced in:
+- [Week 8-10 Schedule]({{ "/puppy-schedule/" | relative_url }})
+- [Week 11-12 Schedule]({{ "/week-11-12/" | relative_url }})
+
+Keep reinforcing crate games as the **weeks progress**—duration and distance will climb while Thunder's confidence stays rock-solid.

--- a/guides/puppy-schedule.md
+++ b/guides/puppy-schedule.md
@@ -112,4 +112,6 @@ When potty is successful, provide **low-arousal, confidence-building activities*
 - [Nutrition Guide]({{ "/nutrition-guide/" | relative_url }}) — Portion control & treat percentages
 - [Vet Quick Reference Guide]({{ "/vet-reference/" | relative_url }}) — Core vaccine series explained
 - [Nighttime Potty Guide]({{ "/nighttime-guide/" | relative_url }}) — Use alongside daytime routine
+- [Crate Training Guide]({{ "/crate-training/" | relative_url }}) — Core den routine games
+- [Command Vocabulary & Markers]({{ "/command-vocabulary/" | relative_url }}) — Exact wording for name and marker cues
 

--- a/guides/week-11-12.md
+++ b/guides/week-11-12.md
@@ -181,6 +181,8 @@ nav_order: 6
 - [Nutrition Guide]({{ "/nutrition-guide/" | relative_url }}) - Portion sizes & feeding schedule
 - [Vet Quick Reference Guide]({{ "/vet-reference/" | relative_url }}) - Vaccination details & prep
 - [Timeline & Budget]({{ "/adoption-plan/" | relative_url }}) - Cost planning for upcoming boarding
+- [Crate Training Guide]({{ "/crate-training/" | relative_url }}) - Extend crate duration & comfort
+- [Command Vocabulary & Markers]({{ "/command-vocabulary/" | relative_url }}) - Quick look-up for cue wording
 
 ---
 

--- a/guides/week-13-16.md
+++ b/guides/week-13-16.md
@@ -27,6 +27,8 @@ nav_order: 7
 - [Grooming Reference Guide]({{ "/grooming-reference/" | relative_url }}) — Continue nail trims during boarding
 - [Nutrition Guide]({{ "/nutrition-guide/" | relative_url }}) — Ensure boarding diet aligns with home routine
 - [Vet Quick Reference Guide]({{ "/vet-reference/" | relative_url }}) — Confirm boarding vaccine requirements
+- [Crate Training Guide]({{ "/crate-training/" | relative_url }}) — Review crate routine before sending to board & train
+- [Command Vocabulary & Markers]({{ "/command-vocabulary/" | relative_url }}) — Ensure trainers use consistent cues
 
 ---
 

--- a/guides/week-17-24.md
+++ b/guides/week-17-24.md
@@ -31,6 +31,8 @@ nav_order: 8
 - [Nutrition Guide]({{ "/nutrition-guide/" | relative_url }}) — Transition toward adult diet
 - [Vet Quick Reference Guide]({{ "/vet-reference/" | relative_url }}) — Adult boosters & health checks
 - [Barking Suppression Guide]({{ "/barking-suppression/" | relative_url }}) — Continue quiet cue reinforcement
+- [Crate Training Guide]({{ "/crate-training/" | relative_url }}) — Maintain overnight routine & travel crate
+- [Command Vocabulary & Markers]({{ "/command-vocabulary/" | relative_url }}) — Refresh cue clarity as commands advance
 
 ---
 


### PR DESCRIPTION
Backlinks were established to enhance navigation and cross-referencing between guides:

*   A new guide, `guides/command-vocabulary.md`, was created to serve as a quick reference for command words and marker cues.
    *   It was added to `_config.yml` to appear in the site's top navigation.
*   Weekly schedule guides were updated to reference core training materials:
    *   `guides/puppy-schedule.md`, `guides/week-11-12.md`, `guides/week-13-16.md`, and `guides/week-17-24.md` now include links to both `guides/crate-training.md` and the new `guides/command-vocabulary.md` within their "Related Guides" sections.
*   Reference guides were updated to link back to relevant schedules:
    *   `guides/crate-training.md` now features a "Where This Fits In" section, linking to `guides/puppy-schedule.md` and `guides/week-11-12.md`, replacing a single return link for broader context.

These changes create a two-way linking structure, allowing users to easily navigate from weekly plans to detailed reference material and vice-versa, improving content discoverability.